### PR TITLE
Fix for multiple ibdiagnet failures

### DIFF
--- a/sysinfo-snapshot.py
+++ b/sysinfo-snapshot.py
@@ -3535,7 +3535,7 @@ def ibdiagnet_handler(card, port, ibdiagnet_suffix):
 
     ibdiagnet_command = "ibdiagnet -r --sharp_opt dsc -i "
     if ibdiagnet_ext_flag:
-        ibdiagnet_command = "ibdiagnet --extended_speeds all -P all --pm_per_lane --skip dup_guids,dup_node_desc,lids,sm,pkey,aguid,virt --get_phy_info --pc --pm_pause_time 10 -i "
+        ibdiagnet_command = "ibdiagnet --extended_speeds all -P all --pm_per_lane --skip dup_guids,dup_node_desc,lids,sm,pkey,aguid,virt --get_phy_info --pm_pause_time 10 -i "
 
     if (ibdiagnet_is_invoked == False):
         if (os.path.exists(path + file_name + "/" + ibdiagnet_suffix +"/ibdiagnet") == False):

--- a/sysinfo-snapshot.py
+++ b/sysinfo-snapshot.py
@@ -3535,7 +3535,7 @@ def ibdiagnet_handler(card, port, ibdiagnet_suffix):
 
     ibdiagnet_command = "ibdiagnet -r --sharp_opt dsc -i "
     if ibdiagnet_ext_flag:
-        ibdiagnet_command = "ibdiagnet --extended_speeds all -P all --pm_per_lane --skip dup_guids,dup_node_desc,lids,sm,pkey,aguid,virt --get_phy_info --pm_pause_time 10 -i "
+        ibdiagnet_command = "ibdiagnet --extended_speeds all -P all --pm_per_lane --skip dup_guids,dup_node_desc,lids,sm,pkey,virt --get_phy_info --pm_pause_time 10 -i "
 
     if (ibdiagnet_is_invoked == False):
         if (os.path.exists(path + file_name + "/" + ibdiagnet_suffix +"/ibdiagnet") == False):

--- a/sysinfo-snapshot.py
+++ b/sysinfo-snapshot.py
@@ -3533,9 +3533,10 @@ def ibdiagnet_handler(card, port, ibdiagnet_suffix):
     global ibdiagnet_res
     global ibdiagnet_error
 
-    ibdiagnet_command = "ibdiagnet -r --sharp_opt dsc -i "
+    ibdiagnet_command = "ibdiagnet -r --sharp_opt dsc "
     if ibdiagnet_ext_flag:
-        ibdiagnet_command = "ibdiagnet --extended_speeds all -P all --pm_per_lane --skip dup_guids,dup_node_desc,lids,sm,pkey,virt --get_phy_info --pm_pause_time 10 -i "
+        ibdiagnet_command += "--extended_speeds all -P all --pm_per_lane --skip dup_guids,dup_node_desc,lids,sm,pkey,virt --get_phy_info --pm_pause_time 10 "
+    ibdiagnet_command +=" -i "
 
     if (ibdiagnet_is_invoked == False):
         if (os.path.exists(path + file_name + "/" + ibdiagnet_suffix +"/ibdiagnet") == False):


### PR DESCRIPTION
Series of patches to fix multiple ibdiagnet failures:
*) Non supported command line options
*) Cleaning counters (needs to be avoided)
*) Dropping routing info for extended diagnostic
*) Failure to detect active ports and not collecting ibdiagnet at all
