### PR TITLE
sysinfo-snapshot: fix ethtool -S links in generated HTML

### DIFF
--- a/sysinfo-snapshot.py
+++ b/sysinfo-snapshot.py
@@ -994,7 +994,6 @@ def ethtool_all_interfaces_handler():
     mellanox_net_devices = all_net_devices
     if (len(mellanox_net_devices) > 0):
         get_status_output("mkdir " + path + file_name + "/ethtool_S")
-        #invoke_command(['mkdir', path + file_name + "/ethtool_S"])
 
     st, ethtool_version = ethtool_version_handler()
     if st != 0:
@@ -1030,13 +1029,12 @@ def ethtool_S_output(mellanox_net_devices):
         st, ethtool_interface = get_status_output(ethtool_command + " " + " -S " + interface)
         if (st != 0 and st != CANCELED_STATUS ):
             ethtool_interface = "Could not run command: ethtool -S " + interface
-        filtered_interface_name = interface.replace(":", "").replace(".", "")
-        file = open(path + file_name + "/ethtool_S/ethtool_S_" + filtered_interface_name, 'w')
+        filtered_interface_name = interface.replace(":", "").replace(".", "").replace("/", "_").replace(" ", "_")
+        artifact_rel_path = "ethtool_S/ethtool_S_" + filtered_interface_name
+        file = open(path + file_name + "/" + artifact_rel_path, 'w')
         file.write(ethtool_interface)
         file.close()
-        res += "ethtool -S " + interface + "\n"
-        res += "<td><a href=ethtool_S/ethtool_S_" + filtered_interface_name + ">ethtool -S " + interface + "</a></td>"
-        res += "\n\n--------------------------------------------------"
+        res += '<a href="' + artifact_rel_path + '">ethtool -S ' + interface + '</a>'
     return res
 #**********************************************************
 #        modinfo Handler
@@ -5542,21 +5540,21 @@ def html_write_paragraph(html, base, collection, dict, prev_parag_end):
         # Add command title/header
         html.write("<h2>"+collection[i]+"</h2>")
         # Add command output/content
-        if ( (original_collection == available_commands_collection)
+        if (collection[i] == "ethtool_all_interfaces") or (collection[i] == "devlink_handler"):
+            content = dict[collection[i]]
+            content = content.split("\n")
+            content_final = ""
+            for line in content:
+                if '<a href' not in line.lower():
+                    content_final += line.replace('<', "&lt;").replace('>', "&gt;") + "\n"
+                else:
+                    content_final += line + "\n"
+            html.write("<p>" + content_final + "</p>")
+        elif ( (original_collection == available_commands_collection)
             and ( collection[i] in available_commands_collection[not is_command_string])):
             array_output_links_collection = ["fw_ini_dump","mst_commands_query_output","asap_parameters","asap_tc_information","rdma_tool","ecn_configuration","doca_pcc_counter","/etc/mlnx_snap","congestion_control_parameters","show_irq_affinity_all","mlxcables","networkManager_system_connections"]
             html.write("<p>")
-            if (collection[i] == "ethtool_all_interfaces") or (collection[i] == "devlink_handler") :
-                content = dict[collection[i]]
-                content = content.split("\n")
-                content_final = ""
-                for line in content:
-                    if "<td><a href=" not in line:
-                        content_final += line.replace('<', "&lt;").replace('>', "&gt;") + "\n"
-                    else:
-                        content_final += line + "\n"
-                html.write(content_final)
-            elif ( collection[i] in array_output_links_collection ):
+            if ( collection[i] in array_output_links_collection ):
                 if("mst_commands_query_output" in collection[i] and non_root):
                     html.write("Running as a non-root user - You must be root to use mst tool")
                     html.write("&nbsp;&nbsp;&nbsp;&nbsp;")


### PR DESCRIPTION
ethtool_all_interfaces is rendered from network_commands_dict, so the link-preserving path in html_write_paragraph never ran and anchor tags were escaped as literal text. Handle ethtool_all_interfaces and devlink_handler before the available_commands_collection check, and detect link lines with a generic '<a href' match.
Build ethtool -S artifact paths with a shared relative path, quoted href attributes, and safer interface-name sanitization so links target the files written under ethtool_S/.

Before this fix the "ethtool -S" portion of the generated HTML looked like:

ethtool -S output:

ethtool -S ib0
<td><a href=ethtool_S/ethtool_S_ib0>ethtool -S ib0</a></td>

--------------------------------------------------

ethtool -S lo
<td><a href=ethtool_S/ethtool_S_lo>ethtool -S lo</a></td>

--------------------------------------------------

ethtool -S oob_net0
<td><a href=ethtool_S/ethtool_S_oob_net0>ethtool -S oob_net0</a></td>

--------------------------------------------------

ethtool -S tmfifo_net0
<td><a href=ethtool_S/ethtool_S_tmfifo_net0>ethtool -S tmfifo_net0</a></td>


Now, the "ethtool -S" portion looks like (each command is underlined hyperlink):

ethtool -S output:

ethtool -S ib0

ethtool -S lo

ethtool -S oob_net0

ethtool -S tmfifo_net0

